### PR TITLE
Remove `baseurl`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,6 @@ description: > # this means to ignore newlines until "baseurl:"
   research, the Hub provides information on educational resources
   focused on polar climate change, including the games, activities,
   and other innovative tools developed by the PoLAR Partnership.
-baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://thepolarhub.org" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings


### PR DESCRIPTION
I emailed GitHub support, and they suggested removing this line to fix our jekyll issues.