### PR TITLE
Fix sort syntax warning

### DIFF
--- a/news-archive.md
+++ b/news-archive.md
@@ -6,7 +6,8 @@ permalink: /news-archive/
 
 All of the latest in PoLAR Partnership news, events, and products.
 
-{% for item in site.news_items | sort: 'date' %}
+{% assign items = site.news_items | sort: 'date' | reverse %}
+{% for item in items %}
 <div class="news-item">
     <h3><a href="{{ item.url }}">{{ item.title }}</a></h3>
     <p>{{ item.description }}</p>


### PR DESCRIPTION
This fixes the warning:

  Liquid syntax error (line 3): Expected end_of_string but found pipe in
  "item in site.news_items | sort: 'date'" in news-archive.md

And corrects the news item sorting to be by date, descending.